### PR TITLE
Dedupe like rows [WIP]

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Below is an example of extracting data from Excel and loading it into a local [p
     loader = PostgresLoader(
         {'database': 'w_drive', 'user': 'bensmithgall', 'host': 'localhost'},
         [{
-            'table_name': 'contracts',
+            'table_name': 'contract',
             'to_relations': [],
             'from_relations': ['company'],
             'pkey': None,
@@ -95,7 +95,7 @@ Below is an example of extracting data from Excel and loading it into a local [p
         },
         {
             'table_name': 'company',
-            'to_relations': ['company_contact', 'contracts'],
+            'to_relations': ['company_contact', 'contract'],
             'from_relations': [],
             'pkey': None,
             'columns': (

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ The Extractor base class is an interface for implementing data extraction from d
 
 The Loader base class is an interface for implementing data loading into new sources. It requires connection parameters (a python dictionary of connection params) and optional schema. The goal is for a single input source (spreadsheet, denormalized table, etc.) to be split into many tables.
 
-##### Current Implemenations:
+##### Current Implementations:
 
-+ Postgres [with relationships!]
++ Postgres [with relationships and simple deduplication!]
 
 ##### TODO Implementations:
 
@@ -36,7 +36,6 @@ The Loader base class is an interface for implementing data loading into new sou
 
 ##### TODO Features:
 
-+ Simple deduplication
 + Add tests
 
 ### Sample Usage

--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ The Loader base class is an interface for implementing data loading into new sou
 ##### TODO Implementations:
 
 + Simple key/value cache (Memcached/Redis)
++ Other relational data stores
 
 ##### TODO Features:
 
-+ Formal foreign key relationshps between table relations in Postgres
++ Simple deduplication
++ Add tests
 
 ### Sample Usage
 
@@ -63,6 +65,7 @@ Below is an example of extracting data from Excel and loading it into a local [p
             'table_name': 'contracts',
             'to_relations': [],
             'from_relations': ['company'],
+            'one_to_many': False,
             'pkey': None,
             'columns': (
                 ('description', 'TEXT'),
@@ -81,6 +84,7 @@ Below is an example of extracting data from Excel and loading it into a local [p
             'table_name': 'company_contact',
             'to_relations': [],
             'from_relations': ['company'],
+            'one_to_many': False,
             'pkey': None,
             'columns': (
                 ('contact_name', 'VARCHAR(255)'),
@@ -96,6 +100,7 @@ Below is an example of extracting data from Excel and loading it into a local [p
             'table_name': 'company',
             'to_relations': ['company_contact', 'contracts'],
             'from_relations': [],
+            'one_to_many': True,
             'pkey': None,
             'columns': (
                 ('company', 'VARCHAR(255)'),

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Below is an example of extracting data from Excel and loading it into a local [p
             'table_name': 'contracts',
             'to_relations': [],
             'from_relations': ['company'],
-            'one_to_many': False,
             'pkey': None,
             'columns': (
                 ('description', 'TEXT'),
@@ -84,7 +83,6 @@ Below is an example of extracting data from Excel and loading it into a local [p
             'table_name': 'company_contact',
             'to_relations': [],
             'from_relations': ['company'],
-            'one_to_many': False,
             'pkey': None,
             'columns': (
                 ('contact_name', 'VARCHAR(255)'),
@@ -100,7 +98,6 @@ Below is an example of extracting data from Excel and loading it into a local [p
             'table_name': 'company',
             'to_relations': ['company_contact', 'contracts'],
             'from_relations': [],
-            'one_to_many': True,
             'pkey': None,
             'columns': (
                 ('company', 'VARCHAR(255)'),

--- a/loaders/postgres.py
+++ b/loaders/postgres.py
@@ -50,7 +50,9 @@ class PostgresLoader(Loader):
         if len(table_schema['columns'][0]) == 1:
             raise Exception('Column Types are not specified')
         elif len(table_schema['columns'][0]) == 2:
-            coldefs = ','.join(
+            coldefs = 'row_id SERIAL,'
+
+            coldefs += ','.join(
                     '{name} {dtype}'.format(name=name, dtype=dtype) for name, dtype in table_schema['columns']
                 )
 
@@ -262,12 +264,13 @@ class PostgresLoader(Loader):
             if n % 10000 == 0:
                 print 'Wrote {n} lines'.format(n=n)
 
-            rowstr = '\t'.join([i[1] for i in row]) + '\n'
+            rowstr = '\t'.join([str(n)] + [i[1] for i in row]) + '\n'
+
             tmp_file.write(rowstr)
 
         tmp_file.seek(0)
 
-        return tmp_file, sorted(data[0].keys())
+        return tmp_file, ['row_id'] + sorted(data[0].keys())
 
     def load(self, data, add_pkey):
         conn = None

--- a/loaders/postgres.py
+++ b/loaders/postgres.py
@@ -60,6 +60,24 @@ class PostgresLoader(Loader):
 
             return create_query
 
+    def generate_foreign_key_query(table, i=0):
+        '''
+        Generates alter table statements that add formal
+        foreign key relationships. Takes in a schema and
+        an optional index (defaults to 0) of the positon
+        of the relationship in the schema
+
+        NOTE: This must be called AFTER data is already
+        loaded. Otherwise, a psycopg2 error will be thrown.
+        '''
+        return '''
+        ALTER TABLE {table} ADD FOREIGN KEY ({id}) REFERENCES {relationship}
+        '''.format(
+            table=table['table_name'],
+            id=table['from_relations'][i] + '_id',
+            relationship=table['from_relations'][i]
+        )
+
     def null_replace(self, field):
         '''
         Replaces empty string, None with 'NULL' for Postgres loading
@@ -176,11 +194,14 @@ class PostgresLoader(Loader):
                 cursor.execute(create_table)
                 tmp_file, column_names = self.generate_data_tempfile(tables[ix])
 
-                tmp_file.seek(0)
-
                 cursor.copy_from(tmp_file, table['table_name'], null='NULL', sep='\t', columns=column_names)
 
-                conn.commit()
+            for table in self.schema:
+                for ix, relationship in enumerate(table['from_relations']):
+                    fk_query = self.generate_foreign_key_query(table, ix)
+                    cursor.execute(fk_query)
+
+            conn.commit()
 
         except psycopg2.Error, e:
             if conn:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
+nose==1.3.4
 psycopg2==2.5.4
+simplejson==3.6.5
+wsgiref==0.1.2
 xlrd==0.9.3


### PR DESCRIPTION
This is a work-in-progress placeholder PR for work against basic de-duplication/collapsing of like rows into a single row using by using row hashes. Replacing the index-based search with hashes allows for fairly good performance. 

~~However, there is one remaining edge case to be resolved, which should be accounted for when the `simple_dedupe` method is implemented and replaces `[dict(item) for item in set([tuple(row.items()) for row in table])]`.~~ This now works as of  53ecbd6
