### PR TITLE
add dtypes to extractor base class

### DIFF
--- a/test/unit/extractors/test_csv_extractor.py
+++ b/test/unit/extractors/test_csv_extractor.py
@@ -75,3 +75,16 @@ class TestCsvExtractor(unittest.TestCase):
                 sorted(row.keys()),
                 ['col1', 'col2', 'col3']
             )
+
+    def test_functional_transform(self):
+        '''
+        Tests that you can apply a function as a dtype
+        '''
+        def add_ten(val):
+            return int(val) + 10
+        extractor = CsvExtractor('./test/mock/csv/file.csv', url=False, dtypes=[str, int, add_ten])
+        data = extractor.extract()
+        # the baz column has ten added to it
+        initial_baz = [2, 20, 200]
+        for idx, row in enumerate(data):
+            self.assertEquals(row.get('baz'), initial_baz[idx] + 10)

--- a/wextractor/extractors/csv.py
+++ b/wextractor/extractors/csv.py
@@ -62,8 +62,9 @@ class CsvExtractor(Extractor):
         output = []
 
         for row in raw_data.split('\n'):
+            data = row.split(',')
             output.append(
-                dict(zip(current_headers, row.split(',')))
+                self.transform_row(current_headers, data)
             )
 
         return output

--- a/wextractor/extractors/excel.py
+++ b/wextractor/extractors/excel.py
@@ -5,7 +5,7 @@ import xlrd
 from wextractor.extractors.extractor import Extractor
 
 class ExcelExtractor(Extractor):
-    def convert_to_python_types(self, row, header, excel_date):
+    def transform_row(self, row, header, excel_date):
         '''
         Attempts to reconcile excel data types with native
         python types. If the ExcelExtractor is initialized with
@@ -86,7 +86,7 @@ class ExcelExtractor(Extractor):
 
             while current_row < current_sheet.nrows:
                 if self.dtypes:
-                    formatted_row = self.convert_to_python_types(
+                    formatted_row = self.transform_row(
                         current_sheet.row(current_row), current_header, workbook.datemode
                     )
                 else:

--- a/wextractor/extractors/extractor.py
+++ b/wextractor/extractors/extractor.py
@@ -18,6 +18,17 @@ class Extractor(object):
             if len(self.header) != len(self.dtypes):
                 raise Exception('Number of headers must match number of dtypes')
 
+    def transform_row(self, header, row):
+        if self.dtypes is None:
+            return dict(zip(header, row))
+        else:
+            output = []
+            for idx, cell in enumerate(row):
+                output.append(
+                    self.dtypes[idx](cell)
+                )
+            return dict(zip(header, output))
+
     def simple_cleanup(self, field):
         '''
         Method to replace spaces with underscores, pound signs


### PR DESCRIPTION
### What Changed
- Added dtypes as a base method that can be overwritten by implementations
- dtypes can now take functions (see `test_functional_transform` in CSV Extractor tests)
### Issues
- Fixes #11 

@codeforamerica/pittsburgh-fellowship-team 
